### PR TITLE
Add penalty for memouts.

### DIFF
--- a/tools/scoring/score.py
+++ b/tools/scoring/score.py
@@ -371,7 +371,8 @@ def score(division,
 
     # Create new dataframe with relevant columns and populate new columns
     data_new = data[['division', 'benchmark', 'family', 'solver', 'solver_id',
-                     'cpu_time', 'wallclock_time', 'result', 'expected']].copy()
+                     'cpu_time', 'wallclock_time', 'status', 'result',
+                     'expected']].copy()
     data_new['year'] = year
     data_new['correct'] = 0       # Number of correctly solved benchmarks
     data_new['error'] = 0         # Number of wrong results
@@ -379,6 +380,10 @@ def score(division,
     data_new['correct_unsat'] = 0 # Number of correctly solved unsat benchmarks
     data_new['division_size'] = num_benchmarks
     data_new['competitive'] = data_new.solver_id.map(is_competitive_solver)
+
+    # Set penalty of 'wclock_limit' seconds for jobs with memouts.
+    data_new.loc[data_new.status == 'memout',
+                 ['cpu_time', 'wallclock_time']] = [wclock_limit, wclock_limit]
 
     # Column 'wrong-answers' only exists in incremental tracks.
     incremental = 'wrong-answers' in data.columns
@@ -394,7 +399,7 @@ def score(division,
     else:
         # Set correct/error column for solved benchmarks.
         solved = data_new[(data_new.result.isin(set(verdicts)))]
-        if g_args.sequential:
+        if sequential:
             solved = solved[(solved.cpu_time <= wclock_limit)]
         else:
             solved = solved[(solved.wallclock_time <= wclock_limit)]


### PR DESCRIPTION
Rationale: If two solvers have the same correctly solved score, we rank by time (CPU or wallclock, depending on the score). If one of the solvers has memouts, this allows for a lower time score if these are not penalized, which may result in unfair comparisons. We thus introduce a penalty (time limit, CPU or wallclock, depending on the score) for memouts. (by @aniemetz)
