### PR TITLE
Update to wrapper scripts for SMTCOMP 2020

### DIFF
--- a/tools/wrap-solvers/README.md
+++ b/tools/wrap-solvers/README.md
@@ -13,20 +13,23 @@ a work around, where we manually download the solvers.
 
 1. ~~Copy `login.sh.template` to `login.sh` and fill in your credentials~~.
 
-   Create a subdirectoy called `download`, where you download all using the default setting.
-   Rename the downloaded zip file to *ID*.zip, where *ID* is the solver id.
+   Create a subdirectoy called `download`, where you download all solvers
+   using the default setting. Rename the downloaded zip file to *ID*.zip,
+   where *ID* is the solver id.
 
 2. Copy a current binary of the
 [trace executor](https://github.com/smt-comp/trace-executor)
 into directory `wrapper_inc`
 
-3. `./wrap_solvers.py <solvers: csv> [ --sq <space: id> ] [ --inc <space_inc: id> ] [ --mv <space_mv: id> ] [ --uc <space_uc: id> ]`
+3. `./wrap_solvers.py <solvers: csv> [ --prelim ] [ --sq <space: id> ] [ --inc <space_inc: id> ] [ --mv <space_mv: id> ] [ --uc <space_uc: id> ]`
 
 ```
 <solvers: csv>   is a csv file with the solver ids as in
                  2020/registration/solvers_divisions_final.csv
 
-<space: id>      the StarExec space id of the solver space for non-incremental
+--prelim         if set, use the preliminary solver ids
+
+<space: id>      the StarExec space id of the solver space for single query
                  solvers
 
 <space_inc: id>  the StarExec space id of the solver space for incremental

--- a/tools/wrap-solvers/README.md
+++ b/tools/wrap-solvers/README.md
@@ -4,20 +4,27 @@ Wrap Solvers for SMT-COMP
 This collection of scripts downloads, wraps and uploads solvers from StarExec
 for SMT-COMP.
 
-It requires the
+It used to require the
 [StarExec command line tool](https://www.starexec.org/starexec/public/starexeccommand.jsp).
 
-1. Copy `login.sh.template` to `login.sh` and fill in your credentials.
+Since the StarExec command line tool is currently not working we have
+a work around, where we manually download the solvers.
+
+
+1. ~~Copy `login.sh.template` to `login.sh` and fill in your credentials~~.
+
+   Create a subdirectoy called `download`, where you download all using the default setting.
+   Rename the downloaded zip file to *ID*.zip, where *ID* is the solver id.
 
 2. Copy a current binary of the
 [trace executor](https://github.com/smt-comp/trace-executor)
 into directory `wrapper_inc`
 
-3. `./wrap_solvers.py <solvers: csv> [ --sq <space: id> [ --inc <space_inc: id> [ --mv <space_mv: id> [ --uc <space_uc: id>]]]]`  
+3. `./wrap_solvers.py <solvers: csv> [ --sq <space: id> ] [ --inc <space_inc: id> ] [ --mv <space_mv: id> ] [ --uc <space_uc: id> ]`
 
 ```
 <solvers: csv>   is a csv file with the solver ids as in
-                 2019/registration/solvers_divisions_final.csv
+                 2020/registration/solvers_divisions_final.csv
 
 <space: id>      the StarExec space id of the solver space for non-incremental
                  solvers
@@ -32,3 +39,9 @@ into directory `wrapper_inc`
                  track solvers
 ```
 
+As of 2020, the solvers have to be uploaded manually.  So the space id
+is currently ignored but some number must be given.  The wrapped
+solvers are put into the directory upload and have to be uploaded
+manually to the corresponding spaces.
+
+Note that in SMT COMP 2020, we only wrap the incremental solvers.

--- a/tools/wrap-solvers/wrap_solver.sh
+++ b/tools/wrap-solvers/wrap_solver.sh
@@ -80,11 +80,13 @@ upload_solver()
 
   SOLVER=$1
   SOLVER_NAME=$2
-  COMMAND="pushsolver f=${SOLVER} n=${SOLVER_NAME} id=${SPACE_ID} downloadable="
-  java -jar ${SCRIPTDIR}/StarexecCommand.jar <<EOF
-login u=${USERNAME} p=${PASSWORD}
-${COMMAND}
-EOF
+#  COMMAND="pushsolver f=${SOLVER} n=${SOLVER_NAME} id=${SPACE_ID} downloadable="
+#  java -jar ${SCRIPTDIR}/StarexecCommand.jar <<EOF
+#login u=${USERNAME} p=${PASSWORD}
+#${COMMAND}
+#EOF
+  mkdir -p upload
+  cp "${SOLVER}" upload
 }
 
 get_solver_info()
@@ -92,11 +94,14 @@ get_solver_info()
   echo ">> get solver info"
 
   ID=$1
-  COMMAND="viewsolver id=${ID}"
-  java -jar ${SCRIPTDIR}/StarexecCommand.jar <<EOF
-login u=${USERNAME} p=${PASSWORD}
-${COMMAND}
-EOF
+#  COMMAND="viewsolver id=${ID}"
+#  java -jar ${SCRIPTDIR}/StarexecCommand.jar <<EOF
+#login u=${USERNAME} p=${PASSWORD}
+#${COMMAND}
+#EOF
+  curl -s 'https://www.starexec.org/starexec/secure/details/solver.jsp?id='${ID} | \
+	perl -ne '/<td>name<\/td>/ and do {$name=1; next }; 
+                  $name && /<td>(.*)<\/td>/ and do { print "name= \"$1\"\n"; exit }'
 }
 
 download_solver()
@@ -105,11 +110,12 @@ download_solver()
 
   ID=$1
   OUT=$2
-  COMMAND="getsolver id=${ID} out=${OUT}"
-  java -jar ${SCRIPTDIR}/StarexecCommand.jar <<EOF
-login u=${USERNAME} p=${PASSWORD}
-${COMMAND}
-EOF
+#  COMMAND="getsolver id=${ID} out=${OUT}"
+#  java -jar ${SCRIPTDIR}/StarexecCommand.jar <<EOF
+#login u=${USERNAME} p=${PASSWORD}
+#${COMMAND}
+#EOF
+  cp download/${ID}.zip "${OUT}"
 }
 
 unzip_solver()

--- a/tools/wrap-solvers/wrap_solver.sh
+++ b/tools/wrap-solvers/wrap_solver.sh
@@ -123,7 +123,7 @@ unzip_solver()
   echo ">> unzip solver"
   SOLVER_DIR=$1
   pushd "${SOLVER_DIR}"
-  unzip -o "${NAME}.zip"
+  unzip -q -o "${NAME}.zip"
   popd
 }
 
@@ -134,7 +134,7 @@ wrap_solver()
   NEW_SOLVER_DIR=$2
   cp -r "${SOLVER_DIR}/${NAME}" "${NEW_SOLVER_DIR}"
   echo "${NEW_SOLVER_DIR}/bin/starexec_run_default"
-  mv "${NEW_SOLVER_DIR}/bin/starexec_run_default" "${NEW_SOLVER_DIR}/bin/original_starexec_run_default"
+  mv "${NEW_SOLVER_DIR}/bin/starexec_run_"* "${NEW_SOLVER_DIR}/bin/original_starexec_run_default"
   res=$?
   cp -r ${WRAPPER_DIR}/* "${NEW_SOLVER_DIR}/bin"
   if [ $res -ne 0 ]
@@ -149,7 +149,7 @@ zip_solver()
   echo ">> zip solver"
   NEW_SOLVER_DIR=$1
   pushd "${NEW_SOLVER_DIR}"
-  zip -r "../${NAME}-${WRAPPED_NAME}.zip" *
+  zip -q -r "../${NAME}-${WRAPPED_NAME}.zip" *
   popd
 }
 

--- a/tools/wrap-solvers/wrap_solver.sh
+++ b/tools/wrap-solvers/wrap_solver.sh
@@ -10,11 +10,13 @@ if [ $# -eq 5 ]
 then
   WRAP=yes
   DOWNLOAD=yes
+  UNZIP=yes
   UPLOAD=yes
   ZIP=yes
 else
   WRAP=no
   DOWNLOAD=no
+  UNZIP=no
   UPLOAD=no
   ZIP=no
 fi
@@ -31,6 +33,7 @@ do
       echo "  options:"
       echo "    -h, --help    print this message and exit"
       echo "    -d            download only"
+      echo "    -x            unzip only"
       echo "    -w            wrap solver only"
       echo "    -u            upload solver only"
       echo "    -z            only zip solver from existing wrapped dir when wrapping"
@@ -39,6 +42,9 @@ do
       ;;
     -d)
       DOWNLOAD=yes
+      ;;
+    -x)
+      UNZIP=yes
       ;;
     -w)
       WRAP=yes
@@ -160,7 +166,7 @@ then
   fi
 fi
 
-[ $DOWNLOAD == "yes" ] && \
+[ $UNZIP == "yes" ] && \
   unzip_solver "${SOLVER_DIR}"
 
 NEW_SOLVER_DIR="${WRAPPED_SOLVER_DIR}/${NAME}-${WRAPPED_NAME}"

--- a/tools/wrap-solvers/wrap_solver.sh
+++ b/tools/wrap-solvers/wrap_solver.sh
@@ -4,7 +4,7 @@
 
 
 SCRIPTDIR=`dirname $(readlink -f "$0")`
-source "$SCRIPTDIR/login.sh"
+#source "$SCRIPTDIR/login.sh"
 
 if [ $# -eq 5 ]
 then

--- a/tools/wrap-solvers/wrap_solvers.py
+++ b/tools/wrap-solvers/wrap_solvers.py
@@ -6,6 +6,7 @@ import subprocess
 import os
 
 COL_SOLVER_ID = 'Solver ID'
+COL_PRELIM_SOLVER_ID = 'Preliminary Solver ID'
 COL_SOLVER_NAME = 'Solver Name'
 COL_SINGLE_QUERY_TRACK = 'Single Query Track'
 COL_INCREMENTAL_TRACK = 'Incremental Track'
@@ -29,6 +30,9 @@ if __name__ == '__main__':
     parser.add_argument ("-d", dest="download_only", action="store_true",
                          default=False,
                          help="download solvers only")
+    parser.add_argument ("-x", dest="unzip_only", action="store_true",
+                         default=False,
+                         help="unzip solvers only")
     parser.add_argument ("-w", dest="wrap_only", action="store_true",
                          default=False,
                          help="wrap solvers only")
@@ -50,7 +54,11 @@ if __name__ == '__main__':
             help="the StarExec space id for model validation track wrapped solvers")
     parser.add_argument ("--uc", dest="space_id_uc",
             help="the StarExec space id for unsat core track wrapped solvers")
+    parser.add_argument ("--prelim", dest="preliminary", action="store_true",
+            help="wrap the preliminary solvers")
     args = parser.parse_args()
+    if args.preliminary:
+        COL_SOLVER_ID = COL_PRELIM_SOLVER_ID
 
     if not os.path.exists(args.csv):
         die("file not found: {}".format(args.csv))
@@ -72,6 +80,8 @@ if __name__ == '__main__':
             add_args = []
             if args.download_only:
                 add_args.append("-d")
+            if args.unzip_only:
+                add_args.append("-x")
             if args.wrap_only:
                 add_args.append("-w")
             if args.upload_only:
@@ -103,7 +113,7 @@ if __name__ == '__main__':
             if args.space_id_inc and incremental_track:
                 print('wrapping for incremental track')
                 script_args.extend(add_args)
-                script_args.extend(['./wrap_solver.sh', 'wrapped-inc', 'wrapper_inc', solver_id, args.space_id_inc, "solvers-inc"])
+                script_args.extend(['wrapped-inc', 'wrapper_inc', solver_id, args.space_id_inc, "solvers-inc"])
                 p = subprocess.Popen(script_args)
                 p.communicate()
 

--- a/tools/wrap-solvers/wrap_solvers.py
+++ b/tools/wrap-solvers/wrap_solvers.py
@@ -63,6 +63,10 @@ if __name__ == '__main__':
     if not os.path.exists(args.csv):
         die("file not found: {}".format(args.csv))
 
+    if args.space_id_inc and \
+       not os.path.exists("wrapper_inc/smtlib2_trace_executor"):
+        die("Please, copy the smtlib2_trace_executor binary to wrapper_inc")
+
     with open(args.csv, 'r') as csvfile:
         reader = csv.reader(csvfile, delimiter=',', quotechar='"')
         header = next(reader)


### PR DESCRIPTION
This does some updates to the wrapper scripts for SMTCOMP 2020, in particular to create the wrapped solvers for the incremental track.

USAGE:

1. make a directory "download".  Download to this directory all solvers and call them *ID*.zip, where *ID* is the solver id. 
2. `python wrap_solvers.py --prelim --inc 1234 ../../2020/registration/solvers_divisions_final.csv`
3. upload the solvers in the upload directory.

Use `--prelim` to use preliminary solvers. The number 1234 should be the space_id for the upload space, but since upload is disabled, it doesn't matter.